### PR TITLE
Not redirecting user if browser is not supported

### DIFF
--- a/examples/playground-js/src/constants/routes.ts
+++ b/examples/playground-js/src/constants/routes.ts
@@ -1,7 +1,6 @@
 export const BASE_ROUTE = "/";
 
 // Misc
-export const BROWSER_NOT_SUPPORTED_ROUTE = BASE_ROUTE + "not_supported";
 export const THANK_YOU_ROUTE = BASE_ROUTE + "thank_you";
 
 // Form

--- a/examples/playground-js/src/landing/layout.tsx
+++ b/examples/playground-js/src/landing/layout.tsx
@@ -9,7 +9,6 @@ import { TRealtimeConfig } from "@outspeed/core";
 import { TRealtimeWebSocketConfig } from "@outspeed/core";
 import { RealtimeExamples } from "./RealtimeExamples";
 import { isChrome, isSafari } from "react-device-detect";
-import { BROWSER_NOT_SUPPORTED_ROUTE } from "../constants/routes";
 import { BrowserNotSupported } from "../components/browser-not-supported";
 
 export type TLandingProps = {};
@@ -30,21 +29,16 @@ export function LandingLayout() {
   const checkBrowser = React.useCallback(() => {
     if (!isChrome && !isSafari) {
       setIsBrowserSupported(false);
-      navigate(BROWSER_NOT_SUPPORTED_ROUTE);
     } else {
       setIsBrowserSupported(true);
     }
-  }, [navigate]);
+  }, []);
 
   React.useEffect(() => {
     checkBrowser();
   }, [checkBrowser]);
 
   if (!isBrowserSupported) {
-    /**
-     * Ideally we will be redirected to `/not_supported` route.
-     * Having this here as a fallback.
-     */
     return <BrowserNotSupported />;
   }
 

--- a/examples/playground-js/src/router.tsx
+++ b/examples/playground-js/src/router.tsx
@@ -3,7 +3,6 @@ import { LandingLayout } from "./landing/layout";
 import {
   APP_ROUTE,
   BASE_ROUTE,
-  BROWSER_NOT_SUPPORTED_ROUTE,
   SCREEN_SHARE_APP_ROUTE,
   SCREEN_SHARE_TAKE_INPUT_ROUTE,
   THANK_YOU_ROUTE,
@@ -19,7 +18,6 @@ import { RealtimeAppLayout } from "./realtime-app/layout";
 import { WebRTCRealtimeApp } from "./realtime-app/webrtc";
 import { WebSocketRealtimeApp } from "./realtime-app/websocket";
 import { WebRTCScreenShareRealtimeApp } from "./realtime-app/webrtc-screen-share";
-import { BrowserNotSupported } from "./components/browser-not-supported";
 import { ThankYouScreen } from "./components/thank-you";
 import { SomethingWentWrong } from "./components/something-went-wrong";
 import { PageNotFound } from "./components/page-not-found";
@@ -68,10 +66,6 @@ const router = createBrowserRouter([
     ],
   },
   // Misc
-  {
-    path: BROWSER_NOT_SUPPORTED_ROUTE,
-    element: <BrowserNotSupported />,
-  },
   {
     path: THANK_YOU_ROUTE,
     element: <ThankYouScreen />,


### PR DESCRIPTION
# Summary

We are currently redirecting users to the `/not-supported` route when they open the playground in Firefox. This approach causes confusion because if the user copies the URL and opens it in Chrome or Safari, they still land on the "browser not supported" page, as the copied URL includes `https://target-url/not-supported` instead of the intended `https://target-url`. 

To resolve this, we will stop redirecting users. Instead, we will display the `<BrowserNotSupported />` component directly without modifying the URL.