### PR TITLE
Redirect users to the homepage upon page reload if they are not on the homepage

### DIFF
--- a/examples/playground-js/src/components/thank-you.tsx
+++ b/examples/playground-js/src/components/thank-you.tsx
@@ -17,7 +17,7 @@ export function ThankYouScreen() {
      * page, hence redirecting the user to the homepage.
      */
     if (!state || state.sessionID !== sessionID) {
-      navigate(BASE_ROUTE);
+      navigate(state?.formURL || BASE_ROUTE);
     }
   }, []);
 

--- a/examples/playground-js/src/components/thank-you.tsx
+++ b/examples/playground-js/src/components/thank-you.tsx
@@ -36,7 +36,7 @@ export function ThankYouScreen() {
               </h2>
               <Button
                 className="inline-flex"
-                onClick={() => navigate(BASE_ROUTE)}
+                onClick={() => navigate(state?.formURL || BASE_ROUTE)}
               >
                 Go to homepage
               </Button>

--- a/examples/playground-js/src/components/thank-you.tsx
+++ b/examples/playground-js/src/components/thank-you.tsx
@@ -1,9 +1,26 @@
-import { useNavigate } from "react-router-dom";
+import { useLoaderData, useLocation, useNavigate } from "react-router-dom";
 import { Button } from "./button";
 import { BASE_ROUTE } from "../constants/routes";
+import React from "react";
+import { TAppRouteLocationState } from "../landing/type";
+import { TLoaderData } from "../types";
 
 export function ThankYouScreen() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const state = location.state as TAppRouteLocationState;
+  const { sessionID } = useLoaderData() as TLoaderData;
+
+  React.useEffect(() => {
+    /**
+     * If session is not equal to state.sessionID, meaning user has reloaded the
+     * page, hence redirecting the user to the homepage.
+     */
+    if (!state || state.sessionID !== sessionID) {
+      navigate(BASE_ROUTE);
+    }
+  }, []);
+
   return (
     <div className="flex justify-center h-dvh w-dvw">
       <div className="flex flex-1 max-w-[1344px] p-4">

--- a/examples/playground-js/src/landing/layout.tsx
+++ b/examples/playground-js/src/landing/layout.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { Outlet, useNavigate } from "react-router-dom";
+import { Outlet, useLoaderData, useNavigate } from "react-router-dom";
 
 import { buttonVariants } from "../components/button";
 import { FileIcon, Github } from "lucide-react";
@@ -11,17 +11,23 @@ import { RealtimeExamples } from "./RealtimeExamples";
 import { isChrome, isSafari } from "react-device-detect";
 import { BROWSER_NOT_SUPPORTED_ROUTE } from "../constants/routes";
 import { BrowserNotSupported } from "../components/browser-not-supported";
+import { TLoaderData } from "../types";
 
 export type TLandingProps = {};
 
 export function LandingLayout() {
   const navigate = useNavigate();
+  const { sessionID } = useLoaderData() as TLoaderData;
+
   const [isBrowserSupported, setIsBrowserSupported] = React.useState(false);
 
   const handleOnSubmit = React.useCallback(
     (config: TRealtimeConfig | TRealtimeWebSocketConfig, pathname: string) => {
       navigate(pathname, {
-        state: { config } satisfies TAppRouteLocationState,
+        state: {
+          config,
+          sessionID,
+        } satisfies TAppRouteLocationState,
       });
     },
     [navigate]

--- a/examples/playground-js/src/landing/layout.tsx
+++ b/examples/playground-js/src/landing/layout.tsx
@@ -1,5 +1,10 @@
 import clsx from "clsx";
-import { Outlet, useLoaderData, useNavigate } from "react-router-dom";
+import {
+  Outlet,
+  useLoaderData,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
 
 import { buttonVariants } from "../components/button";
 import { FileIcon, Github } from "lucide-react";
@@ -17,6 +22,7 @@ export type TLandingProps = {};
 
 export function LandingLayout() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { sessionID } = useLoaderData() as TLoaderData;
 
   const [isBrowserSupported, setIsBrowserSupported] = React.useState(false);
@@ -27,10 +33,11 @@ export function LandingLayout() {
         state: {
           config,
           sessionID,
+          formURL: location.pathname,
         } satisfies TAppRouteLocationState,
       });
     },
-    [navigate]
+    [navigate, location.pathname]
   );
 
   const checkBrowser = React.useCallback(() => {

--- a/examples/playground-js/src/landing/type.ts
+++ b/examples/playground-js/src/landing/type.ts
@@ -10,4 +10,5 @@ export type TLayoutOutletContext = {
 
 export type TAppRouteLocationState = {
   config: TRealtimeConfig | TRealtimeWebSocketConfig;
+  sessionID: number;
 };

--- a/examples/playground-js/src/landing/type.ts
+++ b/examples/playground-js/src/landing/type.ts
@@ -11,4 +11,5 @@ export type TLayoutOutletContext = {
 export type TAppRouteLocationState = {
   config: TRealtimeConfig | TRealtimeWebSocketConfig;
   sessionID: number;
+  formURL: string;
 };

--- a/examples/playground-js/src/realtime-app/layout.tsx
+++ b/examples/playground-js/src/realtime-app/layout.tsx
@@ -20,7 +20,7 @@ export function RealtimeAppLayout() {
   const navigate = useNavigate();
 
   const handleDisconnect = React.useCallback(() => {
-    navigate(THANK_YOU_ROUTE);
+    navigate(THANK_YOU_ROUTE, { state: { sessionID } });
   }, [navigate]);
 
   React.useEffect(() => {

--- a/examples/playground-js/src/realtime-app/layout.tsx
+++ b/examples/playground-js/src/realtime-app/layout.tsx
@@ -20,7 +20,9 @@ export function RealtimeAppLayout() {
   const navigate = useNavigate();
 
   const handleDisconnect = React.useCallback(() => {
-    navigate(THANK_YOU_ROUTE, { state: { sessionID } });
+    navigate(THANK_YOU_ROUTE, {
+      state: { sessionID, formURL: state?.formURL },
+    });
   }, [navigate]);
 
   React.useEffect(() => {
@@ -33,11 +35,11 @@ export function RealtimeAppLayout() {
      * `state.sessionID` not matching `sessionID` indicates a browser reload.
      */
     if (!state || state.sessionID !== sessionID) {
-      navigate(BASE_ROUTE);
+      navigate(state?.formURL || BASE_ROUTE);
     }
   }, [state, sessionID]);
 
-  if (!state || !state.config) {
+  if (!state || !state.config || state.sessionID !== sessionID) {
     return null;
   }
 

--- a/examples/playground-js/src/realtime-app/layout.tsx
+++ b/examples/playground-js/src/realtime-app/layout.tsx
@@ -1,13 +1,22 @@
-import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import {
+  Outlet,
+  useLoaderData,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
 import { TAppRouteLocationState } from "../landing/type";
 import { TRealtimeAppContext } from "./types";
 import React from "react";
 import { BASE_ROUTE, THANK_YOU_ROUTE } from "../constants/routes";
 import { RealtimeToast } from "@outspeed/react";
+import { TLoaderData } from "../types";
 
 export function RealtimeAppLayout() {
   const location = useLocation();
+  const { sessionID } = useLoaderData() as TLoaderData;
+
   const state = location.state as TAppRouteLocationState;
+
   const navigate = useNavigate();
 
   const handleDisconnect = React.useCallback(() => {
@@ -15,10 +24,18 @@ export function RealtimeAppLayout() {
   }, [navigate]);
 
   React.useEffect(() => {
-    if (!state) {
+    /**
+     * If the state is `undefined` or if `state.sessionID` does not match the
+     * expected `sessionID`, we redirect to the homepage.
+     *
+     * The state is undefined typically due to a bug.
+     *
+     * `state.sessionID` not matching `sessionID` indicates a browser reload.
+     */
+    if (!state || state.sessionID !== sessionID) {
       navigate(BASE_ROUTE);
     }
-  }, [state]);
+  }, [state, sessionID]);
 
   if (!state || !state.config) {
     return null;

--- a/examples/playground-js/src/realtime-app/webrtc-screen-share.tsx
+++ b/examples/playground-js/src/realtime-app/webrtc-screen-share.tsx
@@ -12,6 +12,7 @@ export function WebRTCScreenShareRealtimeApp() {
 
   const {
     connectionStatus,
+    response,
     connect,
     disconnect,
     getRemoteAudioTrack,
@@ -37,8 +38,6 @@ export function WebRTCScreenShareRealtimeApp() {
         description: "Failed to connect.",
         variant: "destructive",
       });
-      disconnect();
-      onDisconnect();
     }
   }, [connectionStatus, connect, onDisconnect, config]);
 
@@ -63,8 +62,17 @@ export function WebRTCScreenShareRealtimeApp() {
       <div className="h-full flex flex-1 justify-center items-center">
         <div className="flex items-center space-y-4 flex-col">
           <h2 className="text-3xl font-light">
-            Failed to connect. Please try again.
+            Failed to connect.{" "}
+            {(response?.data as any)?.detail || "Please try again."}
           </h2>
+          <details className="max-w-lg overflow-auto">
+            <summary>See Response</summary>
+            <pre className="bg-gray-800 text-gray-100 p-4 rounded-lg overflow-x-auto">
+              <code className="language-js text-sm">
+                {JSON.stringify(response, undefined, 2)}
+              </code>
+            </pre>
+          </details>
           <Button
             className="inline-flex max-w-24"
             onClick={() => window.location.reload()}

--- a/examples/playground-js/src/realtime-app/webrtc.tsx
+++ b/examples/playground-js/src/realtime-app/webrtc.tsx
@@ -11,9 +11,9 @@ export function WebRTCRealtimeApp() {
   const { config, onDisconnect } = useOutletContext<TRealtimeAppContext>();
   const { toast } = useRealtimeToast();
 
-  console.log("Config", config);
   const {
     connectionStatus,
+    response,
     connect,
     disconnect,
     getRemoteAudioTrack,
@@ -39,8 +39,6 @@ export function WebRTCRealtimeApp() {
         description: "Failed to connect.",
         variant: "destructive",
       });
-      disconnect();
-      onDisconnect();
     }
   }, [connectionStatus, connect, onDisconnect, config]);
 
@@ -65,8 +63,17 @@ export function WebRTCRealtimeApp() {
       <div className="h-full flex flex-1 justify-center items-center">
         <div className="flex items-center space-y-4 flex-col">
           <h2 className="text-3xl font-light">
-            Failed to connect. Please try again.
+            Failed to connect.{" "}
+            {(response?.data as any)?.detail || "Please try again."}
           </h2>
+          <details className="max-w-lg overflow-auto">
+            <summary>See Response</summary>
+            <pre className="bg-gray-800 text-gray-100 p-4 rounded-lg overflow-x-auto">
+              <code className="language-js text-sm">
+                {JSON.stringify(response, undefined, 2)}
+              </code>
+            </pre>
+          </details>
           <Button
             className="inline-flex max-w-24"
             onClick={() => window.location.reload()}

--- a/examples/playground-js/src/realtime-app/websocket.tsx
+++ b/examples/playground-js/src/realtime-app/websocket.tsx
@@ -13,6 +13,7 @@ export function WebSocketRealtimeApp() {
 
   const {
     connect,
+    response,
     disconnect,
     getRemoteAudioTrack,
     getLocalAudioTrack,
@@ -51,8 +52,17 @@ export function WebSocketRealtimeApp() {
       <div className="h-full flex flex-1 justify-center items-center">
         <div className="flex items-center space-y-4 flex-col">
           <h2 className="text-3xl font-light">
-            Failed to connect. Please try again.
+            Failed to connect.{" "}
+            {(response?.data as any)?.detail || "Please try again."}
           </h2>
+          <details className="max-w-lg overflow-auto">
+            <summary>See Response</summary>
+            <pre className="bg-gray-800 text-gray-100 p-4 rounded-lg overflow-x-auto">
+              <code className="language-js text-sm">
+                {JSON.stringify(response, undefined, 2)}
+              </code>
+            </pre>
+          </details>
           <Button
             className="inline-flex max-w-24"
             onClick={() => window.location.reload()}

--- a/examples/playground-js/src/router.tsx
+++ b/examples/playground-js/src/router.tsx
@@ -87,6 +87,9 @@ const router = createBrowserRouter([
   },
   {
     path: THANK_YOU_ROUTE,
+    loader: () => {
+      return json({ sessionID });
+    },
     element: <ThankYouScreen />,
   },
   {

--- a/examples/playground-js/src/router.tsx
+++ b/examples/playground-js/src/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from "react-router-dom";
+import { createBrowserRouter, json } from "react-router-dom";
 import { LandingLayout } from "./landing/layout";
 import {
   APP_ROUTE,
@@ -24,11 +24,21 @@ import { ThankYouScreen } from "./components/thank-you";
 import { SomethingWentWrong } from "./components/something-went-wrong";
 import { PageNotFound } from "./components/page-not-found";
 
+/**
+ * Every time the browser reloads, we will get a new sessionID.
+ * We will use this sessionID to track whether the browser is
+ * reloaded.
+ */
+const sessionID = new Date().getTime();
+
 const router = createBrowserRouter([
   {
     path: BASE_ROUTE,
     element: <LandingLayout />,
     errorElement: <SomethingWentWrong />,
+    loader: () => {
+      return json({ sessionID });
+    },
     children: [
       {
         path: "/",
@@ -52,6 +62,9 @@ const router = createBrowserRouter([
     path: APP_ROUTE,
     element: <RealtimeAppLayout />,
     errorElement: <SomethingWentWrong />,
+    loader: () => {
+      return json({ sessionID });
+    },
     children: [
       {
         path: WEB_RTC_APP_ROUTE,

--- a/examples/playground-js/src/types.ts
+++ b/examples/playground-js/src/types.ts
@@ -1,0 +1,3 @@
+export type TLoaderData = {
+  sessionID: number;
+};

--- a/packages/core/src/RealtimeConnection/RealtimeConnection.ts
+++ b/packages/core/src/RealtimeConnection/RealtimeConnection.ts
@@ -156,6 +156,7 @@ export class RealtimeConnection {
 
     if (!response.ok) {
       return {
+        ...response,
         error: `Failed during negotiating connection. Response: ${response.error}.`,
       };
     }

--- a/packages/core/src/RealtimeConnection/RealtimeConnectionNegotiator.ts
+++ b/packages/core/src/RealtimeConnection/RealtimeConnectionNegotiator.ts
@@ -40,6 +40,7 @@ export class RealtimeConnectionNegotiator {
       const response = await this._getOfferURL(this._config.functionURL);
       if (!response.ok) {
         return {
+          ...response,
           error: "Failed during getting offer URL.",
         };
       }
@@ -52,6 +53,7 @@ export class RealtimeConnectionNegotiator {
         "Neither offerURL nor functionURL is provided"
       );
       return {
+        ...response,
         error: "Neither offerURL nor functionURL is provided",
       };
     }
@@ -62,6 +64,7 @@ export class RealtimeConnectionNegotiator {
 
     if (!response.ok) {
       return {
+        ...response,
         error: "Failed during modifying sdp before sending offer.",
       };
     }
@@ -77,6 +80,7 @@ export class RealtimeConnectionNegotiator {
 
     if (!response.ok) {
       return {
+        ...response,
         error:
           "Failed during sending offer or during setting remote description.",
       };
@@ -144,6 +148,13 @@ export class RealtimeConnectionNegotiator {
   private async _getOfferURL(functionURL: string): Promise<TResponse> {
     try {
       const response = await fetchWithRetry(functionURL, undefined, 7);
+
+      if (!response.ok) {
+        return {
+          error: "Failed to get offerURL.",
+          data: await response.json(),
+        };
+      }
 
       const payload = (await response.json()) as unknown;
 
@@ -272,8 +283,18 @@ export class RealtimeConnectionNegotiator {
           },
           method: "POST",
         },
-        7
+        7,
+        undefined,
+        [400]
       );
+
+      if (!response.ok) {
+        this._logger?.error(this._logLabel, "Unable to get the offer URL.");
+        return {
+          error: "Unable to get the offer.",
+          data: await response.json(),
+        };
+      }
 
       const answer = (await response.json()) as unknown;
 

--- a/packages/core/src/RealtimeWebSocket/RealtimeWebSocketConnection.ts
+++ b/packages/core/src/RealtimeWebSocket/RealtimeWebSocketConnection.ts
@@ -60,6 +60,10 @@ export class RealtimeWebSocketConnection {
         retryOnFail
       );
 
+      if (!response.ok) {
+        return response;
+      }
+
       const payload = (await response.json()) as unknown;
 
       // Waiting for connection to start.
@@ -67,8 +71,14 @@ export class RealtimeWebSocketConnection {
       await fetchWithRetry(
         functionURL.replace(/\/$/, "") + "/connections",
         undefined,
-        retryOnFail
+        retryOnFail,
+        undefined,
+        [400]
       );
+
+      if (!response.ok) {
+        return response;
+      }
 
       if (!payload || typeof payload !== "object") {
         throw new Error(
@@ -214,10 +224,8 @@ export class RealtimeWebSocketConnection {
         `Failed to connect to ${config.functionURL}`,
         response
       );
-      return { error: "Failed to connect" };
+      return { ...response, error: "Failed to connect" };
     }
-
-    console.log("So", response.data);
 
     this.socket = new WebSocket(response.data, config.protocols);
     this.dataChannel = new WebSocketDataChannel(this.socket);

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -84,7 +84,8 @@ export async function fetchWithRetry(
   url: string,
   options: RequestInit = {},
   retries: number = 3,
-  backoff: number = 1000
+  backoff: number = 1000,
+  ignoreRetryIfStatusCodeIs: number[] = []
 ): Promise<Response> {
   for (let i = 0; i < retries; i++) {
     try {
@@ -93,6 +94,8 @@ export async function fetchWithRetry(
 
       // If the response is ok (status in the range 200-299), return it
       if (response.ok) {
+        return response;
+      } else if (ignoreRetryIfStatusCodeIs.includes(response.status)) {
         return response;
       } else {
         throw new Error(`Request failed with status ${response.status}`);

--- a/packages/react/src/components/realtime-chat.tsx
+++ b/packages/react/src/components/realtime-chat.tsx
@@ -87,7 +87,6 @@ export function RealtimeChat(props: RealtimeChatProps) {
               <div dangerouslySetInnerHTML={{ __html: message.render }} />
             ),
           });
-          console.log();
         }
 
         updateMessage({ ...message, type: "bot" });

--- a/packages/react/src/hooks/useWebRTC.ts
+++ b/packages/react/src/hooks/useWebRTC.ts
@@ -323,6 +323,7 @@ export function useWebRTC(options: TUseWebRTCOptions) {
 
   return {
     connectionStatus: actor.value,
+    response: actor.context.connectionResponse,
     connect,
     disconnect,
     reset,

--- a/packages/react/src/hooks/useWebSocket.ts
+++ b/packages/react/src/hooks/useWebSocket.ts
@@ -3,6 +3,7 @@ import {
   RealtimeWebSocketConnection,
   Track,
   TRealtimeWebSocketConfig,
+  TResponse,
 } from "@outspeed/core";
 
 export type TUseWebSocketOptions = {
@@ -22,6 +23,7 @@ export function useWebSocket(options: TUseWebSocketOptions) {
     React.useState<RealtimeWebSocketConnection | null>(null);
   const [connectionStatus, setConnectionStatus] =
     React.useState<TWebSocketConnectionStatus>("new");
+  const [response, setResponse] = React.useState<TResponse>({});
   const [remoteTrack, setRemoteTrack] = React.useState<Track | null>(null);
 
   const connect = React.useCallback(async () => {
@@ -32,10 +34,12 @@ export function useWebSocket(options: TUseWebSocketOptions) {
       // This will release media, if it is setup.
       await ws.disconnect();
       setConnectionStatus("failed");
+      setResponse(response);
       return console.error("Failed to connect", response);
     }
     setConnection(ws);
     setConnectionStatus("connected");
+    setResponse(response);
   }, [config]);
 
   const disconnect = React.useCallback(async () => {
@@ -74,5 +78,6 @@ export function useWebSocket(options: TUseWebSocketOptions) {
     getLocalAudioTrack,
     getRemoteAudioTrack,
     connection,
+    response,
   };
 }


### PR DESCRIPTION
# Summary

This PR addresses the issue of page reload behavior. Previously, when users reloaded the page while on the WebRTC App, WebSocket App, or thank you page, they would remain on the same page. This behavior is not ideal as users might prefer to return to the landing page. This PR resolves this issue.

# Changes

In this PR, a `sessionID` key is introduced in `router.tsx` and passed to all routes using `loader`. The `sessionID` resets upon browser reload. When transitioning from the form page to an app page (such as the WebRTC App or WebSocket App), the `sessionID` is passed along. Upon reloading the app page, the component checks if `location.state.sessionID` matches `loaderData.sessionID`. If they do not match, indicating a browser reload, the user is redirected to the index page.

# Testing
- Tested in Chrome browser, and it works as expected.

# Notes

**Why do we need `sessionID`?**
- Data is passed using `location.state`. When users move from the form page to the app page, data is set in `location.state` and persists even after a page refresh. The app page logic initiates a connection if `location.state` is defined, which is currently happening. To prevent this, we need a mechanism that changes upon page reload, hence the `sessionID`.

**Alternative Considerations:**
- Other options were not explored extensively as this solution is straightforward to implement. An alternative could involve using `window.onbeforeunload = navigate(location.pathname, { replace: true, state: null });` and additional variables to maintain the old state, but this approach is more complex.

