### PR TITLE
Update exports and type resolutions, optimize bundle size

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,104 +18,150 @@
     "./constants": {
       "types": "./dist/constants.d.ts",
       "import": "./dist/constants.mjs",
-      "require": "./dist/constants.js",
-      "default": "./dist/constants.js"
+      "require": "./dist/constants.js"
     },
     "./create-config": {
       "types": "./dist/create-config.d.ts",
       "import": "./dist/create-config.mjs",
-      "require": "./dist/create-config.js",
-      "default": "./dist/create-config.js"
+      "require": "./dist/create-config.js"
     },
-    "./DataChannel/DataChannel": {
+    "./DataChannel": {
       "types": "./dist/DataChannel/DataChannel.d.ts",
       "import": "./dist/DataChannel/DataChannel.mjs",
-      "require": "./dist/DataChannel/DataChannel.js",
-      "default": "./dist/DataChannel/DataChannel.js"
+      "require": "./dist/DataChannel/DataChannel.js"
     },
-    "./DataChannel/WebRTCDataChannel": {
+    "./WebRTCDataChannel": {
       "types": "./dist/DataChannel/WebRTCDataChannel.d.ts",
       "import": "./dist/DataChannel/WebRTCDataChannel.mjs",
-      "require": "./dist/DataChannel/WebRTCDataChannel.js",
-      "default": "./dist/DataChannel/WebRTCDataChannel.js"
+      "require": "./dist/DataChannel/WebRTCDataChannel.js"
     },
-    "./DataChannel/WebSocketDataChannel": {
+    "./WebSocketDataChannel": {
       "types": "./dist/DataChannel/WebSocketDataChannel.d.ts",
       "import": "./dist/DataChannel/WebSocketDataChannel.mjs",
-      "require": "./dist/DataChannel/WebSocketDataChannel.js",
-      "default": "./dist/DataChannel/WebSocketDataChannel.js"
+      "require": "./dist/DataChannel/WebSocketDataChannel.js"
     },
-    "./Logger/ConsoleLogger": {
+    "./ConsoleLogger": {
       "types": "./dist/Logger/ConsoleLogger.d.ts",
       "import": "./dist/Logger/ConsoleLogger.mjs",
-      "require": "./dist/Logger/ConsoleLogger.js",
-      "default": "./dist/Logger/ConsoleLogger.js"
+      "require": "./dist/Logger/ConsoleLogger.js"
     },
-    "./Logger/Logger": {
+    "./Logger": {
       "types": "./dist/Logger/Logger.d.ts",
       "import": "./dist/Logger/Logger.mjs",
-      "require": "./dist/Logger/Logger.js",
-      "default": "./dist/Logger/Logger.js"
+      "require": "./dist/Logger/Logger.js"
     },
-    "./machine/realtime-connection": {
+    "./realtime-connection": {
       "types": "./dist/machine/realtime-connection.d.ts",
       "import": "./dist/machine/realtime-connection.mjs",
-      "require": "./dist/machine/realtime-connection.js",
-      "default": "./dist/machine/realtime-connection.js"
+      "require": "./dist/machine/realtime-connection.js"
     },
-    "./RealtimeConnection/RealtimeConnection": {
+    "./RealtimeConnection": {
       "types": "./dist/RealtimeConnection/RealtimeConnection.d.ts",
       "import": "./dist/RealtimeConnection/RealtimeConnection.mjs",
-      "require": "./dist/RealtimeConnection/RealtimeConnection.js",
-      "default": "./dist/RealtimeConnection/RealtimeConnection.js"
+      "require": "./dist/RealtimeConnection/RealtimeConnection.js"
     },
-    "./RealtimeConnection/RealtimeConnectionMediaManager": {
+    "./RealtimeConnectionMediaManager": {
       "types": "./dist/RealtimeConnection/RealtimeConnectionMediaManager.d.ts",
       "import": "./dist/RealtimeConnection/RealtimeConnectionMediaManager.mjs",
-      "require": "./dist/RealtimeConnection/RealtimeConnectionMediaManager.js",
-      "default": "./dist/RealtimeConnection/RealtimeConnectionMediaManager.js"
+      "require": "./dist/RealtimeConnection/RealtimeConnectionMediaManager.js"
     },
-    "./RealtimeConnection/RealtimeConnectionNegotiator": {
+    "./RealtimeConnectionNegotiator": {
       "types": "./dist/RealtimeConnection/RealtimeConnectionNegotiator.d.ts",
       "import": "./dist/RealtimeConnection/RealtimeConnectionNegotiator.mjs",
-      "require": "./dist/RealtimeConnection/RealtimeConnectionNegotiator.js",
-      "default": "./dist/RealtimeConnection/RealtimeConnectionNegotiator.js"
+      "require": "./dist/RealtimeConnection/RealtimeConnectionNegotiator.js"
     },
-    "./RealtimeWebSocket/RealtimeWebsocketAudioProcessor.worklet": {
+    "./RealtimeWebsocketAudioProcessor.worklet": {
       "types": "./dist/RealtimeWebSocket/RealtimeWebsocketAudioProcessor.worklet.d.ts",
       "import": "./dist/RealtimeWebSocket/RealtimeWebsocketAudioProcessor.worklet.mjs",
-      "require": "./dist/RealtimeWebSocket/RealtimeWebsocketAudioProcessor.worklet.js",
-      "default": "./dist/RealtimeWebSocket/RealtimeWebsocketAudioProcessor.worklet.js"
+      "require": "./dist/RealtimeWebSocket/RealtimeWebsocketAudioProcessor.worklet.js"
     },
-    "./RealtimeWebSocket/RealtimeWebSocketConnection": {
+    "./RealtimeWebSocketConnection": {
       "types": "./dist/RealtimeWebSocket/RealtimeWebSocketConnection.d.ts",
       "import": "./dist/RealtimeWebSocket/RealtimeWebSocketConnection.mjs",
-      "require": "./dist/RealtimeWebSocket/RealtimeWebSocketConnection.js",
-      "default": "./dist/RealtimeWebSocket/RealtimeWebSocketConnection.js"
+      "require": "./dist/RealtimeWebSocket/RealtimeWebSocketConnection.js"
     },
-    "./RealtimeWebSocket/RealtimeWebSocketMediaManager": {
+    "./RealtimeWebSocketMediaManager": {
       "types": "./dist/RealtimeWebSocket/RealtimeWebSocketMediaManager.d.ts",
       "import": "./dist/RealtimeWebSocket/RealtimeWebSocketMediaManager.mjs",
-      "require": "./dist/RealtimeWebSocket/RealtimeWebSocketMediaManager.js",
-      "default": "./dist/RealtimeWebSocket/RealtimeWebSocketMediaManager.js"
+      "require": "./dist/RealtimeWebSocket/RealtimeWebSocketMediaManager.js"
     },
-    "./SDP/SDP": {
+    "./SDP": {
       "types": "./dist/SDP/SDP.d.ts",
       "import": "./dist/SDP/SDP.mjs",
-      "require": "./dist/SDP/SDP.js",
-      "default": "./dist/SDP/SDP.js"
+      "require": "./dist/SDP/SDP.js"
     },
-    "./shared/Track": {
+    "./@types": {
+      "types": "./dist/shared/@types.d.ts",
+      "import": "./dist/shared/@types.mjs",
+      "require": "./dist/shared/@types.js"
+    },
+    "./Track": {
       "types": "./dist/shared/Track.d.ts",
       "import": "./dist/shared/Track.mjs",
-      "require": "./dist/shared/Track.js",
-      "default": "./dist/shared/Track.js"
+      "require": "./dist/shared/Track.js"
     },
     "./utils": {
       "types": "./dist/utils.d.ts",
       "import": "./dist/utils.mjs",
-      "require": "./dist/utils.js",
-      "default": "./dist/utils.js"
+      "require": "./dist/utils.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "constants": [
+        "./dist/constants.d.ts"
+      ],
+      "create-config": [
+        "./dist/create-config.d.ts"
+      ],
+      "DataChannel": [
+        "./dist/DataChannel/DataChannel.d.ts"
+      ],
+      "WebRTCDataChannel": [
+        "./dist/DataChannel/WebRTCDataChannel.d.ts"
+      ],
+      "WebSocketDataChannel": [
+        "./dist/DataChannel/WebSocketDataChannel.d.ts"
+      ],
+      "ConsoleLogger": [
+        "./dist/Logger/ConsoleLogger.d.ts"
+      ],
+      "Logger": [
+        "./dist/Logger/Logger.d.ts"
+      ],
+      "realtime-connection": [
+        "./dist/machine/realtime-connection.d.ts"
+      ],
+      "RealtimeConnection": [
+        "./dist/RealtimeConnection/RealtimeConnection.d.ts"
+      ],
+      "RealtimeConnectionMediaManager": [
+        "./dist/RealtimeConnection/RealtimeConnectionMediaManager.d.ts"
+      ],
+      "RealtimeConnectionNegotiator": [
+        "./dist/RealtimeConnection/RealtimeConnectionNegotiator.d.ts"
+      ],
+      "RealtimeWebsocketAudioProcessor.worklet": [
+        "./dist/RealtimeWebSocket/RealtimeWebsocketAudioProcessor.worklet.d.ts"
+      ],
+      "RealtimeWebSocketConnection": [
+        "./dist/RealtimeWebSocket/RealtimeWebSocketConnection.d.ts"
+      ],
+      "RealtimeWebSocketMediaManager": [
+        "./dist/RealtimeWebSocket/RealtimeWebSocketMediaManager.d.ts"
+      ],
+      "SDP": [
+        "./dist/SDP/SDP.d.ts"
+      ],
+      "@types": [
+        "./dist/shared/@types.d.ts"
+      ],
+      "Track": [
+        "./dist/shared/Track.d.ts"
+      ],
+      "utils": [
+        "./dist/utils.d.ts"
+      ]
     }
   },
   "files": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -15,103 +15,139 @@
         "default": "./dist/index.js"
       }
     },
-    "./components/realtime-audio-input": {
+    "./realtime-audio-input": {
       "types": "./dist/components/realtime-audio-input.d.ts",
       "import": "./dist/components/realtime-audio-input.mjs",
-      "require": "./dist/components/realtime-audio-input.js",
-      "default": "./dist/components/realtime-audio-input.js"
+      "require": "./dist/components/realtime-audio-input.js"
     },
-    "./components/realtime-audio-visualizer": {
+    "./realtime-audio-visualizer": {
       "types": "./dist/components/realtime-audio-visualizer.d.ts",
       "import": "./dist/components/realtime-audio-visualizer.mjs",
-      "require": "./dist/components/realtime-audio-visualizer.js",
-      "default": "./dist/components/realtime-audio-visualizer.js"
+      "require": "./dist/components/realtime-audio-visualizer.js"
     },
-    "./components/realtime-audio": {
+    "./realtime-audio": {
       "types": "./dist/components/realtime-audio.d.ts",
       "import": "./dist/components/realtime-audio.mjs",
-      "require": "./dist/components/realtime-audio.js",
-      "default": "./dist/components/realtime-audio.js"
+      "require": "./dist/components/realtime-audio.js"
     },
-    "./components/realtime-chat": {
+    "./realtime-chat": {
       "types": "./dist/components/realtime-chat.d.ts",
       "import": "./dist/components/realtime-chat.mjs",
-      "require": "./dist/components/realtime-chat.js",
-      "default": "./dist/components/realtime-chat.js"
+      "require": "./dist/components/realtime-chat.js"
     },
-    "./components/realtime-connection-status": {
+    "./realtime-connection-status": {
       "types": "./dist/components/realtime-connection-status.d.ts",
       "import": "./dist/components/realtime-connection-status.mjs",
-      "require": "./dist/components/realtime-connection-status.js",
-      "default": "./dist/components/realtime-connection-status.js"
+      "require": "./dist/components/realtime-connection-status.js"
     },
-    "./components/realtime-form": {
+    "./realtime-form": {
       "types": "./dist/components/realtime-form.d.ts",
       "import": "./dist/components/realtime-form.mjs",
-      "require": "./dist/components/realtime-form.js",
-      "default": "./dist/components/realtime-form.js"
+      "require": "./dist/components/realtime-form.js"
     },
-    "./components/realtime-function-url-input": {
+    "./realtime-function-url-input": {
       "types": "./dist/components/realtime-function-url-input.d.ts",
       "import": "./dist/components/realtime-function-url-input.mjs",
-      "require": "./dist/components/realtime-function-url-input.js",
-      "default": "./dist/components/realtime-function-url-input.js"
+      "require": "./dist/components/realtime-function-url-input.js"
     },
-    "./components/realtime-share-screen-input": {
+    "./realtime-share-screen-input": {
       "types": "./dist/components/realtime-share-screen-input.d.ts",
       "import": "./dist/components/realtime-share-screen-input.mjs",
-      "require": "./dist/components/realtime-share-screen-input.js",
-      "default": "./dist/components/realtime-share-screen-input.js"
+      "require": "./dist/components/realtime-share-screen-input.js"
     },
-    "./components/realtime-toast": {
+    "./realtime-toast": {
       "types": "./dist/components/realtime-toast.d.ts",
       "import": "./dist/components/realtime-toast.mjs",
-      "require": "./dist/components/realtime-toast.js",
-      "default": "./dist/components/realtime-toast.js"
+      "require": "./dist/components/realtime-toast.js"
     },
-    "./components/realtime-video-input": {
+    "./realtime-video-input": {
       "types": "./dist/components/realtime-video-input.d.ts",
       "import": "./dist/components/realtime-video-input.mjs",
-      "require": "./dist/components/realtime-video-input.js",
-      "default": "./dist/components/realtime-video-input.js"
+      "require": "./dist/components/realtime-video-input.js"
     },
-    "./components/realtime-video": {
+    "./realtime-video": {
       "types": "./dist/components/realtime-video.d.ts",
       "import": "./dist/components/realtime-video.mjs",
-      "require": "./dist/components/realtime-video.js",
-      "default": "./dist/components/realtime-video.js"
+      "require": "./dist/components/realtime-video.js"
     },
-    "./hooks/useAvailableMediaDevices": {
+    "./useAvailableMediaDevices": {
       "types": "./dist/hooks/useAvailableMediaDevices.d.ts",
       "import": "./dist/hooks/useAvailableMediaDevices.mjs",
-      "require": "./dist/hooks/useAvailableMediaDevices.js",
-      "default": "./dist/hooks/useAvailableMediaDevices.js"
+      "require": "./dist/hooks/useAvailableMediaDevices.js"
     },
-    "./hooks/useCreateConfig": {
+    "./useCreateConfig": {
       "types": "./dist/hooks/useCreateConfig.d.ts",
       "import": "./dist/hooks/useCreateConfig.mjs",
-      "require": "./dist/hooks/useCreateConfig.js",
-      "default": "./dist/hooks/useCreateConfig.js"
+      "require": "./dist/hooks/useCreateConfig.js"
     },
-    "./hooks/useRealtimeToast": {
+    "./useRealtimeToast": {
       "types": "./dist/hooks/useRealtimeToast.d.ts",
       "import": "./dist/hooks/useRealtimeToast.mjs",
-      "require": "./dist/hooks/useRealtimeToast.js",
-      "default": "./dist/hooks/useRealtimeToast.js"
+      "require": "./dist/hooks/useRealtimeToast.js"
     },
-    "./hooks/useWebRTC": {
+    "./useWebRTC": {
       "types": "./dist/hooks/useWebRTC.d.ts",
       "import": "./dist/hooks/useWebRTC.mjs",
-      "require": "./dist/hooks/useWebRTC.js",
-      "default": "./dist/hooks/useWebRTC.js"
+      "require": "./dist/hooks/useWebRTC.js"
     },
-    "./hooks/useWebSocket": {
+    "./useWebSocket": {
       "types": "./dist/hooks/useWebSocket.d.ts",
       "import": "./dist/hooks/useWebSocket.mjs",
-      "require": "./dist/hooks/useWebSocket.js",
-      "default": "./dist/hooks/useWebSocket.js"
+      "require": "./dist/hooks/useWebSocket.js"
     },
     "./styles.css": "./dist/styles.css"
+  },
+  "typesVersions": {
+    "*": {
+      "realtime-audio-input": [
+        "./dist/components/realtime-audio-input.d.ts"
+      ],
+      "realtime-audio-visualizer": [
+        "./dist/components/realtime-audio-visualizer.d.ts"
+      ],
+      "realtime-audio": [
+        "./dist/components/realtime-audio.d.ts"
+      ],
+      "realtime-chat": [
+        "./dist/components/realtime-chat.d.ts"
+      ],
+      "realtime-connection-status": [
+        "./dist/components/realtime-connection-status.d.ts"
+      ],
+      "realtime-form": [
+        "./dist/components/realtime-form.d.ts"
+      ],
+      "realtime-function-url-input": [
+        "./dist/components/realtime-function-url-input.d.ts"
+      ],
+      "realtime-share-screen-input": [
+        "./dist/components/realtime-share-screen-input.d.ts"
+      ],
+      "realtime-toast": [
+        "./dist/components/realtime-toast.d.ts"
+      ],
+      "realtime-video-input": [
+        "./dist/components/realtime-video-input.d.ts"
+      ],
+      "realtime-video": [
+        "./dist/components/realtime-video.d.ts"
+      ],
+      "useAvailableMediaDevices": [
+        "./dist/hooks/useAvailableMediaDevices.d.ts"
+      ],
+      "useCreateConfig": [
+        "./dist/hooks/useCreateConfig.d.ts"
+      ],
+      "useRealtimeToast": [
+        "./dist/hooks/useRealtimeToast.d.ts"
+      ],
+      "useWebRTC": [
+        "./dist/hooks/useWebRTC.d.ts"
+      ],
+      "useWebSocket": [
+        "./dist/hooks/useWebSocket.d.ts"
+      ]
+    }
   },
   "files": [
     "dist/",

--- a/packages/react/src/components/realtime-audio-visualizer.tsx
+++ b/packages/react/src/components/realtime-audio-visualizer.tsx
@@ -1,4 +1,4 @@
-import { Track } from "@outspeed/core";
+import { Track } from "@outspeed/core/Track";
 import React from "react";
 
 export type RealtimeAudioVisualizerProps = {
@@ -101,7 +101,6 @@ function lerp(start: number, end: number) {
 
 function setupDraw(threshold: number) {
   const indexes = [5, 8, 10, 14, 16, 18, 20];
-  const dpr = window.devicePixelRatio || 1;
 
   const prevRadius = indexes.map(() => 0);
 

--- a/packages/react/src/components/realtime-audio.tsx
+++ b/packages/react/src/components/realtime-audio.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { Track } from "@outspeed/core";
+import { Track } from "@outspeed/core/Track";
 
 export type RealtimeAudioProps = {
   track: Track | null;

--- a/packages/react/src/components/realtime-chat.tsx
+++ b/packages/react/src/components/realtime-chat.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 
-import { DataChannel, isMessageEvent } from "@outspeed/core";
+import { DataChannel } from "@outspeed/core/DataChannel";
+import { isMessageEvent } from "@outspeed/core/utils";
 import { useRealtimeToast } from "../hooks";
 import { Cross1Icon } from "@radix-ui/react-icons";
 import { Input } from "./__internal/input";

--- a/packages/react/src/components/realtime-video.tsx
+++ b/packages/react/src/components/realtime-video.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { Track } from "@outspeed/core";
+import { Track } from "@outspeed/core/Track";
 
 export type RealtimeVideoProps = {
   track: Track | null;

--- a/packages/react/src/hooks/useAvailableMediaDevices.ts
+++ b/packages/react/src/hooks/useAvailableMediaDevices.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { getAllUserMedia } from "@outspeed/core";
+import { getAllUserMedia } from "@outspeed/core/utils";
 
 export function useAvailableMediaDevices() {
   const [availableAudioDevices, setAvailableAudioDevices] = React.useState(

--- a/packages/react/src/hooks/useCreateConfig.ts
+++ b/packages/react/src/hooks/useCreateConfig.ts
@@ -1,12 +1,12 @@
 import React from "react";
+import { createConfig } from "@outspeed/core/create-config";
+import { Logger } from "@outspeed/core/Logger";
 import {
-  createConfig,
-  Logger,
   TAudioCodec,
   TRealtimeConfig,
   TVideoCodec,
   TVideoTransform,
-} from "@outspeed/core";
+} from "@outspeed/core/@types";
 
 /**
  * The shape of the variables used to create a configuration.

--- a/packages/react/src/hooks/useWebRTC.ts
+++ b/packages/react/src/hooks/useWebRTC.ts
@@ -1,16 +1,14 @@
 import { useActor } from "@xstate/react";
 import React from "react";
 import {
-  isRTCTrackEvent,
-  realtimeConnectionMachine,
   TRealtimeConnectionListener,
   TRealtimeConnectionListenerType,
-  TRealtimeConfig,
-  Track,
-  WebRTCDataChannel,
-  ETrackOrigin,
-  ETrackKind,
-} from "@outspeed/core";
+} from "@outspeed/core/RealtimeConnection";
+import { isRTCTrackEvent } from "@outspeed/core/utils";
+import { realtimeConnectionMachine } from "@outspeed/core/realtime-connection";
+import { WebRTCDataChannel } from "@outspeed/core/WebRTCDataChannel";
+import { Track, ETrackOrigin, ETrackKind } from "@outspeed/core/Track";
+import { TRealtimeConfig } from "@outspeed/core/@types";
 
 export type TUseWebRTCReturn<T = unknown> = {
   ok?: boolean;

--- a/packages/react/src/hooks/useWebSocket.ts
+++ b/packages/react/src/hooks/useWebSocket.ts
@@ -1,10 +1,7 @@
 import React from "react";
-import {
-  RealtimeWebSocketConnection,
-  Track,
-  TRealtimeWebSocketConfig,
-  TResponse,
-} from "@outspeed/core";
+import { Track } from "@outspeed/core/Track";
+import { RealtimeWebSocketConnection } from "@outspeed/core/RealtimeWebSocketConnection";
+import { TRealtimeWebSocketConfig, TResponse } from "@outspeed/core/@types";
 
 export type TUseWebSocketOptions = {
   config: TRealtimeWebSocketConfig;

--- a/scripts/check-exports.js
+++ b/scripts/check-exports.js
@@ -25,51 +25,53 @@ function checkAllPathsInExport(exportPaths) {
     if (!fs.existsSync(base.require)) {
       throw new Error(`${base.require} doesn't exist`);
     }
-    if (!fs.existsSync(base.default)) {
-      throw new Error(`${base.default} doesn't exist`);
-    }
   }
 }
 
 function getAllExports(directory) {
   const files = fs.readdirSync(directory);
   let newExports = {};
+  let typesVersions = {};
   for (const file of files) {
     const filepath = path.join(directory, file);
 
     if (fs.lstatSync(filepath).isDirectory()) {
-      newExports = { ...newExports, ...getAllExports(filepath) };
+      const { newExports: _n, typesVersions: _t } = getAllExports(filepath);
+      newExports = { ...newExports, ..._n };
+      typesVersions = { ...typesVersions, ..._t };
       continue;
     }
 
     if (
       !filepath.endsWith(".js") ||
       filepath.includes("index") ||
-      filepath.includes("@types") ||
       filepath.includes("__internal")
     )
       continue;
 
     const relativePath = path.relative(dist, directory);
     const filename = file.replace(".js", "");
-    const importName = relativePath ? `${relativePath}/${filename}` : filename;
-    const typesPath = `./dist/${importName}.d.ts`;
-    const importPath = `./dist/${importName}.mjs`;
-    const requirePath = `./dist/${importName}.js`;
-    const defaultPath = `./dist/${importName}.js`;
+    const relativeImportPath = relativePath
+      ? `${relativePath}/${filename}`
+      : filename;
 
-    newExports[`./${importName}`] = {
+    // Exports
+    const typesPath = `./dist/${relativeImportPath}.d.ts`;
+    const importPath = `./dist/${relativeImportPath}.mjs`;
+    const requirePath = `./dist/${relativeImportPath}.js`;
+
+    newExports[`./${filename}`] = {
       types: typesPath,
       import: importPath,
       require: requirePath,
-      default: defaultPath,
     };
+    typesVersions[filename] = [typesPath];
   }
 
-  return newExports;
+  return { newExports, typesVersions };
 }
 
-const newExports = getAllExports(dist);
+const { newExports, typesVersions } = getAllExports(dist);
 checkAllPathsInExport(newExports);
 
 // Reading package.json
@@ -97,7 +99,16 @@ packageJson.exports = {
   ...additionalExport,
 };
 
+packageJson.typesVersions = {
+  "*": typesVersions,
+};
+
 console.log(
   "All exports exist, you can copy the following exports object into your package.json."
 );
-console.log(newExports);
+
+console.log("All exports");
+console.log(JSON.stringify(packageJson.exports, undefined, 2));
+
+console.log("All typesVersions");
+console.log(JSON.stringify(packageJson.typesVersions, undefined, 2));


### PR DESCRIPTION
# Summary of Changes:
1. Updated `exports` in `package.json` 
   - Modified the `exports` field to ensure better control over module resolution, allowing only the necessary files to be exposed.
   
2. Updated `typesVersions` in `package.json`:
   - Added the correct paths for TypeScript type resolutions.

3. Update the scripts (`check-exports.js`)
   - Now handles generating the correct `exports` and `typesVersions` fields.

4. Optimized imports in `@outspeed/react`:
   - Updated imports from `@outspeed/core` to ensure that only necessary modules are imported, this will reduce the bundle size.

# Notes:
- **Why `typesVersions` and `exports` were updated:**  
  These fields are essential for proper module resolution in modern JavaScript and TypeScript environments. The `exports` field allows us to explicitly define which modules are accessible from outside the package, improving build performance. The `typesVersions` field ensures that TypeScript picks up the correct type declarations, especially for consumers using different TypeScript versions.

- This will require up to update the docs little bit.