### PR TITLE
Fix playground permission bug

### DIFF
--- a/examples/playground-js/src/components/user-media-permission-explanation.tsx
+++ b/examples/playground-js/src/components/user-media-permission-explanation.tsx
@@ -1,0 +1,37 @@
+import { Button } from "./button";
+
+export type TUserMediaPermissionExplanationProps = {
+  handlePermission: () => void;
+};
+
+export function UserMediaPermissionExplanation(
+  props: TUserMediaPermissionExplanationProps
+) {
+  const { handlePermission } = props;
+
+  return (
+    <div className="leading-relaxed">
+      <h4 className="mb-4 text-2xl font-bold">
+        We Need Your Camera and Microphone Access
+      </h4>
+
+      <p className="mb-2">
+        Our examples needs access to your camera and microphone.
+      </p>
+      <ul className="list-disc ml-6 space-y-3">
+        <li>
+          <span className="font-semibold">Camera Access</span>: We need this to
+          capture and stream your video when required for video examples.
+        </li>
+        <li>
+          <span className="font-semibold">Microphone Access</span>: This is
+          needed to capture and stream your audio.
+        </li>
+      </ul>
+
+      <div className="mt-6">
+        <Button onClick={handlePermission}>Grant Access</Button>
+      </div>
+    </div>
+  );
+}

--- a/examples/playground-js/src/components/user-media-permission-failed.tsx
+++ b/examples/playground-js/src/components/user-media-permission-failed.tsx
@@ -1,0 +1,50 @@
+export function UserMediaPermissionFailed() {
+  return (
+    <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative">
+      <strong className="font-bold">Permission Denied!</strong>
+      <p className="mt-2">
+        It looks like you denied access to your camera or microphone.
+      </p>
+      <p className="mb-2">
+        Our examples needs access to your camera and microphone.
+      </p>
+      <ul className="list-disc ml-6 space-y-3">
+        <li>
+          <span className="font-semibold">Camera Access</span>: We need this to
+          capture and stream your video when required for video examples.
+        </li>
+        <li>
+          <span className="font-semibold">Microphone Access</span>: This is
+          needed to capture and stream your audio.
+        </li>
+      </ul>
+
+      <p className="mt-4 mb-2">To reset the permission on:</p>
+      <ul className="list-disc ml-6 mt-2">
+        <li>
+          <span className="font-semibold">Chrome</span> follow the instructions{" "}
+          <a
+            href="https://support.google.com/chrome/answer/2693767?hl=en&co=GENIE.Platform%3DDesktop"
+            target="_blank"
+            className="text-blue-800 underline"
+          >
+            available here
+          </a>
+          .
+        </li>
+
+        <li>
+          <span className="font-semibold">Safari</span> follow the instructions{" "}
+          <a
+            href="https://support.poodll.com/en/support/solutions/articles/19000125983-setting-webcam-and-mic-permissions-on-desktop-safari"
+            target="_blank"
+            className="text-blue-800 underline"
+          >
+            available here
+          </a>
+          .
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/examples/playground-js/src/components/user-media-permission-failed.tsx
+++ b/examples/playground-js/src/components/user-media-permission-failed.tsx
@@ -34,15 +34,16 @@ export function UserMediaPermissionFailed() {
         </li>
 
         <li>
-          <span className="font-semibold">Safari</span> follow the instructions{" "}
-          <a
-            href="https://support.poodll.com/en/support/solutions/articles/19000125983-setting-webcam-and-mic-permissions-on-desktop-safari"
-            target="_blank"
-            className="text-blue-800 underline"
-          >
-            available here
-          </a>
-          .
+          <span className="font-semibold">iPhone/iPad (iOS)</span> Go to
+          Settings. Scroll down and find Safari. Tap on Camera or Microphone.
+          Change the setting to either Ask or Allow.
+        </li>
+        <li>
+          <span className="font-semibold">MacOS Safari</span> Click Safari in
+          the menu bar and select Settings (or Preferences on older versions).
+          Go to the Websites tab. In the left-hand panel, find Camera and
+          Microphone. Locate this Outspeed's playground URL and set the
+          permission to Allow or Ask.
         </li>
       </ul>
     </div>

--- a/examples/playground-js/src/components/user-media-permission-failed.tsx
+++ b/examples/playground-js/src/components/user-media-permission-failed.tsx
@@ -43,7 +43,8 @@ export function UserMediaPermissionFailed() {
           the menu bar and select Settings (or Preferences on older versions).
           Go to the Websites tab. In the left-hand panel, find Camera and
           Microphone. Locate this Outspeed's playground URL and set the
-          permission to Allow or Ask.
+          permission to Allow or Ask. If it's already set to Ask, try refreshing
+          the page.
         </li>
       </ul>
     </div>

--- a/examples/playground-js/src/components/user-media-permission-modal.tsx
+++ b/examples/playground-js/src/components/user-media-permission-modal.tsx
@@ -1,0 +1,39 @@
+import { AudioLinesIcon, Video } from "lucide-react";
+
+export function UserMediaPermissionModal() {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-background rounded-lg shadow-lg p-8 max-w-md mx-auto">
+        <div className="flex justify-start space-x-2 mb-4">
+          <AudioLinesIcon />
+          <Video />
+        </div>
+
+        <h2 className="text-2xl font-bold text-gray-50 mb-4">
+          Allow Camera and Microphone Access
+        </h2>
+
+        <p className="text-gray-300 mb-6">
+          To continue, please allow access to your camera and microphone when
+          prompted by your browser. Our examples needs access to your camera and
+          microphone.
+        </p>
+        <ul className="list-disc ml-6 space-y-3">
+          <li>
+            <span className="font-semibold">Camera Access</span>: We need this
+            to capture and stream your video when required for video examples.
+          </li>
+          <li>
+            <span className="font-semibold">Microphone Access</span>: This is
+            needed to capture and stream your audio.
+          </li>
+        </ul>
+
+        <p className="text-gray-500 text-sm mt-8">
+          If you don't see the popup, check your browser's address bar for the
+          permission request.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/examples/playground-js/src/landing/layout.tsx
+++ b/examples/playground-js/src/landing/layout.tsx
@@ -80,6 +80,21 @@ export function LandingLayout() {
     } catch (error) {
       console.error("[Handle User Media Permission Error]", error);
 
+      if (isSafari) {
+        /**
+         * If user denied or dismissed the permission on Safari, then
+         * we can't ask for permission again using javascript. Safari,
+         * requires user intervention to reset the permission.
+         *
+         * If user has selected "Don't Allow" then it can be fixed by
+         * refreshing the page, but if user has selected "Never Ask Again",
+         * then user has to manually reset the permission. In the instructions
+         * component, we have provided the steps to reset the permission.
+         */
+        setUserMediaPermissionStatus("failed");
+        return;
+      }
+
       const permissionStatus = await getUserMediaPermissionStatus();
       if (permissionStatus.state === "prompt") {
         setUserMediaPermissionStatus("dismissed");
@@ -102,8 +117,10 @@ export function LandingLayout() {
   }, [checkBrowser]);
 
   React.useEffect(() => {
-    handlePermission();
-  }, []);
+    if (userMediaPermissionStatus === "init" && isBrowserSupported) {
+      handlePermission();
+    }
+  }, [isBrowserSupported, handlePermission]);
 
   if (!isBrowserSupported) {
     return <BrowserNotSupported />;

--- a/examples/playground-js/src/landing/layout.tsx
+++ b/examples/playground-js/src/landing/layout.tsx
@@ -10,8 +10,11 @@ import { buttonVariants } from "../components/button";
 import { FileIcon, Github } from "lucide-react";
 import { TAppRouteLocationState, TLayoutOutletContext } from "./type";
 import React, { useState } from "react";
-import { TRealtimeConfig } from "@outspeed/core";
-import { TRealtimeWebSocketConfig } from "@outspeed/core";
+import {
+  TRealtimeWebSocketConfig,
+  TRealtimeConfig,
+  getUserMediaPermissionStatus,
+} from "@outspeed/core";
 import { RealtimeExamples } from "./RealtimeExamples";
 import { isChrome, isSafari } from "react-device-detect";
 import { BrowserNotSupported } from "../components/browser-not-supported";
@@ -21,13 +24,6 @@ import { UserMediaPermissionExplanation } from "../components/user-media-permiss
 import { UserMediaPermissionFailed } from "../components/user-media-permission-failed";
 
 export type TLandingProps = {};
-
-async function getPermissionStatus() {
-  // @ts-ignore
-  const response = await navigator.permissions.query({ name: "camera" });
-
-  return response;
-}
 
 export function LandingLayout() {
   const navigate = useNavigate();
@@ -53,7 +49,7 @@ export function LandingLayout() {
   );
 
   const handlePermission = React.useCallback(async () => {
-    const permissionStatus = await getPermissionStatus();
+    const permissionStatus = await getUserMediaPermissionStatus();
 
     if (permissionStatus.state === "granted") {
       setUserMediaPermissionStatus("success");
@@ -84,7 +80,7 @@ export function LandingLayout() {
     } catch (error) {
       console.error("[Handle User Media Permission Error]", error);
 
-      const permissionStatus = await getPermissionStatus();
+      const permissionStatus = await getUserMediaPermissionStatus();
       if (permissionStatus.state === "prompt") {
         setUserMediaPermissionStatus("dismissed");
       } else {
@@ -95,7 +91,7 @@ export function LandingLayout() {
 
   const checkBrowser = React.useCallback(() => {
     if (!isChrome && !isSafari) {
-      setIsBrowserSupported(false);
+      setIsBrowserSupported(true);
     } else {
       setIsBrowserSupported(true);
     }

--- a/examples/playground-js/src/landing/layout.tsx
+++ b/examples/playground-js/src/landing/layout.tsx
@@ -91,7 +91,7 @@ export function LandingLayout() {
 
   const checkBrowser = React.useCallback(() => {
     if (!isChrome && !isSafari) {
-      setIsBrowserSupported(true);
+      setIsBrowserSupported(false);
     } else {
       setIsBrowserSupported(true);
     }

--- a/examples/playground-js/src/landing/layout.tsx
+++ b/examples/playground-js/src/landing/layout.tsx
@@ -9,20 +9,33 @@ import {
 import { buttonVariants } from "../components/button";
 import { FileIcon, Github } from "lucide-react";
 import { TAppRouteLocationState, TLayoutOutletContext } from "./type";
-import React from "react";
+import React, { useState } from "react";
 import { TRealtimeConfig } from "@outspeed/core";
 import { TRealtimeWebSocketConfig } from "@outspeed/core";
 import { RealtimeExamples } from "./RealtimeExamples";
 import { isChrome, isSafari } from "react-device-detect";
 import { BrowserNotSupported } from "../components/browser-not-supported";
 import { TLoaderData } from "../types";
+import { UserMediaPermissionModal } from "../components/user-media-permission-modal";
+import { UserMediaPermissionExplanation } from "../components/user-media-permission-explanation";
+import { UserMediaPermissionFailed } from "../components/user-media-permission-failed";
 
 export type TLandingProps = {};
+
+async function getPermissionStatus() {
+  // @ts-ignore
+  const response = await navigator.permissions.query({ name: "camera" });
+
+  return response;
+}
 
 export function LandingLayout() {
   const navigate = useNavigate();
   const location = useLocation();
   const { sessionID } = useLoaderData() as TLoaderData;
+  const [userMediaPermissionStatus, setUserMediaPermissionStatus] = useState<
+    "init" | "pending" | "success" | "dismissed" | "failed"
+  >("init");
 
   const [isBrowserSupported, setIsBrowserSupported] = React.useState(false);
 
@@ -39,6 +52,47 @@ export function LandingLayout() {
     [navigate, location.pathname]
   );
 
+  const handlePermission = React.useCallback(async () => {
+    const permissionStatus = await getPermissionStatus();
+
+    if (permissionStatus.state === "granted") {
+      setUserMediaPermissionStatus("success");
+      return;
+    }
+
+    if (permissionStatus.state === "denied") {
+      setUserMediaPermissionStatus("failed");
+      return;
+    }
+
+    setUserMediaPermissionStatus("pending");
+    try {
+      /**
+       * Asking for user's permission so that we have access
+       * to the name of user's devices available.
+       */
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: true,
+        video: true,
+      });
+
+      stream.getTracks().forEach(function (track) {
+        track.stop();
+      });
+
+      setUserMediaPermissionStatus("success");
+    } catch (error) {
+      console.error("[Handle User Media Permission Error]", error);
+
+      const permissionStatus = await getPermissionStatus();
+      if (permissionStatus.state === "prompt") {
+        setUserMediaPermissionStatus("dismissed");
+      } else {
+        setUserMediaPermissionStatus("failed");
+      }
+    }
+  }, []);
+
   const checkBrowser = React.useCallback(() => {
     if (!isChrome && !isSafari) {
       setIsBrowserSupported(false);
@@ -51,12 +105,16 @@ export function LandingLayout() {
     checkBrowser();
   }, [checkBrowser]);
 
+  React.useEffect(() => {
+    handlePermission();
+  }, []);
+
   if (!isBrowserSupported) {
     return <BrowserNotSupported />;
   }
 
   return (
-    <div className="flex h-dvh w-dvw flex-col items-center md:items-stretch md:flex-row">
+    <div className="flex h-dvh w-full flex-col items-center md:items-stretch md:flex-row">
       <div className="flex-1 bg-[hsl(204,80%,5%)] w-full flex justify-center md:justify-end">
         <div className="flex-1 p-4 flex flex-col max-w-lg md:max-w-2xl">
           {/* Logo */}
@@ -83,14 +141,42 @@ export function LandingLayout() {
       </div>
       <div className="flex-1 flex w-full justify-center md:justify-start">
         <div className="flex-1 flex flex-col max-w-lg justify-center md:px-10 md:max-w-2xl p-4">
-          <div className="mb-4 p-4 text-red-500 text-lg border border-red-500 rounded">
-            Please ensure that the app is running and Function URL is correct.
-          </div>
-          <Outlet
-            context={
-              { onSubmit: handleOnSubmit } satisfies TLayoutOutletContext
-            }
-          />
+          {userMediaPermissionStatus === "success" && (
+            <>
+              <div className="mb-4 p-4 text-red-500 text-lg border border-red-500 rounded">
+                Please ensure that the app is running and Function URL is
+                correct.
+              </div>
+              <Outlet
+                context={
+                  { onSubmit: handleOnSubmit } satisfies TLayoutOutletContext
+                }
+              />
+            </>
+          )}
+          {userMediaPermissionStatus === "pending" && (
+            <UserMediaPermissionModal />
+          )}
+          {userMediaPermissionStatus === "dismissed" && (
+            /**
+             * If user has dismissed the popup, then we are showing
+             * a message that why we need camera and microphone access.
+             *
+             * Also, have a button that user can use top see the media
+             * access permission popup again.
+             */
+            <UserMediaPermissionExplanation
+              handlePermission={handlePermission}
+            />
+          )}
+          {userMediaPermissionStatus === "failed" && (
+            /**
+             * If the user has denied the permission, then we can't do anything
+             * using javascript to as for permission again, hence we are showing
+             * a message explaining what user can do to reset permission.
+             */
+            <UserMediaPermissionFailed />
+          )}
         </div>
       </div>
       <div className="w-full justify-center mt-16 flex md:hidden">

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -55,6 +55,18 @@ export async function getAllUserMediaWithoutAskingForPermission(): Promise<TAllU
   };
 }
 
+export async function getUserMediaPermissionStatus() {
+  // @ts-expect-error name: "camera" is defined
+  const response = await navigator.permissions.query({ name: "camera" });
+
+  if (response.state === "granted") {
+    // @ts-expect-error name: "microphone" is defined
+    return await navigator.permissions.query({ name: "microphone" });
+  }
+
+  return response;
+}
+
 export async function getAllUserMedia(): Promise<TAllUserMedia> {
   let stream: undefined | MediaStream;
   try {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -55,7 +55,25 @@ export async function getAllUserMediaWithoutAskingForPermission(): Promise<TAllU
   };
 }
 
-export async function getUserMediaPermissionStatus() {
+/**
+ * Asynchronously checks the current permission status for the camera and microphone.
+ *
+ * @returns {Promise<PermissionStatus>} A Promise that resolves to the permission status of the camera
+ * and microphone.
+ *
+ * @example
+ * const permissionStatus = await getUserMediaPermissionStatus()
+ *
+ * if (permissionStatus.state === 'granted') {
+ *  console.log('Camera and microphone permissions are granted.');
+ * } else if (permissionStatus.state === 'denied') {
+ *  console.log('Camera or microphone permissions are denied.');
+ * } else {
+ *  console.log('User has not responded to the permission request.');
+ * }
+ *
+ */
+export async function getUserMediaPermissionStatus(): Promise<PermissionStatus> {
   // @ts-expect-error name: "camera" is defined
   const response = await navigator.permissions.query({ name: "camera" });
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -36,7 +36,7 @@ export async function getAllUserMediaWithoutAskingForPermission(): Promise<TAllU
     return mediaDevices.map((device, idx) => {
       const label = device.label ? device.label : `${type} #${idx}`;
       return {
-        deviceId: device.deviceId,
+        deviceId: device.deviceId || label,
         groupId: device.groupId,
         kind: device.kind,
         label,

--- a/packages/react/src/components/realtime-audio-input.tsx
+++ b/packages/react/src/components/realtime-audio-input.tsx
@@ -62,7 +62,7 @@ export function RealtimeAudioInput(props: TRealtimeAudioInputProps) {
     if (availableAudioDevices.length > 0 && !value && !placeholder) {
       onChange(availableAudioDevices[0].deviceId);
     }
-  }, [availableAudioDevices, placeholder]);
+  }, [availableAudioDevices, onChange, placeholder, value]);
 
   return (
     <FormItem>

--- a/packages/react/src/components/realtime-video-input.tsx
+++ b/packages/react/src/components/realtime-video-input.tsx
@@ -61,7 +61,7 @@ export function RealtimeVideoInput(props: TRealtimeVideoInputProps) {
     if (availableVideoDevices.length > 0 && !value && !placeholder) {
       onChange(availableVideoDevices[0].deviceId);
     }
-  }, [availableVideoDevices, placeholder]);
+  }, [availableVideoDevices, onChange, placeholder, value]);
 
   return (
     <FormItem>


### PR DESCRIPTION
# Summary

 ### 1. Improved Handling of Media Permission.
- Previously, when a user denied camera or microphone permissions, they were redirected to an error page.
- **Update**: Users will now be shown a clear message explaining why camera/microphone access is required and what steps they can take to reset the permissions, providing a better user experience and preventing confusion.

### 2. Permission Request Modal on Mount
- When the app requests media permissions (camera/microphone), we now show a modal explaining the need for access upfront.
- **Update**: This modal appears immediately on mount, helping users understand the reason behind the permission request before taking any action.

### 3. New Utility Function: `getUserMediaPermissionStatus` in `@outspeed/core`
- checks and returns the current status of media permissions.
